### PR TITLE
use arg for upx image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ run go build -o /copy -ldflags '-s -w' github.com/tonistiigi/copy/cmd/copy
 
 from ${UPX_IMG} AS upx
 copy --from=main /copy /copy
-run ["upx", "/copy"]
+run upx /copy
 
 from alpine AS wget
 workdir /out

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,3 +58,5 @@ copy --from=release /bin/ /bin/
 entrypoint ["ash"]
 
 from release-${TARGETOS}-${TARGETARCH} AS release
+arg TARGETOS
+arg TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ from wget AS xz
 run wget http://s.minos.io/archive/bifrost/x86_64/xz-5.0.3-1.tar.gz
 run tar xvf xz-5.0.3-1.tar.gz  -C /out
 
-from scratch AS release
+from scratch AS release-linux-amd64
 copy --from=upx /copy /bin/
 # copy --from=cp /bin/cp /bin/
 copy --from=tar /out/bin /bin/
@@ -43,8 +43,18 @@ copy --from=bz /out/bin /bin/
 copy --from=xz /out/usr/bin /bin/
 entrypoint ["/bin/copy"]
 
+from alpine AS release-alt
+run apk add -U --no-cache tar gzip bzip2 xz && mv /usr/bin/bz* /bin/
+copy --from=upx /copy /bin/
+entrypoint ["/bin/copy"]
+
+from release-alt AS release-linux-arm64
+from release-alt AS release-linux-arm
+from release-alt AS release-linux-s390x
+from release-alt AS release-linux-ppc64le
+
 from alpine as dev-env
 copy --from=release /bin/ /bin/
 entrypoint ["ash"]
 
-from release
+from release-${TARGETOS}-${TARGETARCH} AS release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
+arg UPX_IMG=gruebel/upx
+
 from golang:1.10-alpine AS main
 workdir /go/src/github.com/tonistiigi/copy
 copy . .
 env CGO_ENABLED=0
 run go build -o /copy -ldflags '-s -w' github.com/tonistiigi/copy/cmd/copy
 
-from gruebel/upx AS upx
+from ${UPX_IMG} AS upx
 copy --from=main /copy /copy
 run ["upx", "/copy"]
 


### PR DESCRIPTION
This will allow the user to build using a different `upx` image. Helpful for specifying a `upx` image of a different architecture.

e.g.
```
$ docker build --build-arg UPX_IMG=andrewhsu/upx:aarch64 .
```

cc @tonistiigi @tiborvass 