### PR TITLE
allow xattr error

### DIFF
--- a/cmd/copy/main.go
+++ b/cmd/copy/main.go
@@ -134,10 +134,15 @@ func runCopy(ctx context.Context, args []string, opt opts) error {
 }
 
 func runCp(ctx context.Context, srcs []string, dest string, opt opts) error {
+	xattrErrorHandler := func(dst, src, key string, err error) error {
+		log.Println(err)
+		return nil
+	}
 	for _, src := range srcs {
-		if err := copy.Copy(ctx, src, dest, copy.AllowWildcards, func(ci *copy.CopyInfo) {
-			ci.Chown = opt.chown
-		}); err != nil {
+		if err := copy.Copy(ctx, src, dest, copy.AllowWildcards, copy.WithXAttrErrorHandler(xattrErrorHandler),
+			func(ci *copy.CopyInfo) {
+				ci.Chown = opt.chown
+			}); err != nil {
 			return errors.Wrapf(err, "failed to copy %s to %s", src, dest)
 		}
 	}

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/moby/buildkit 277037a77f32b689df342c2ac7ea1c093be4b52e
-github.com/tonistiigi/fsutil ecf259bc9d815143037535521910285f47f321ef
+github.com/tonistiigi/fsutil 11b4bc7505e4558833cf30344d84e225766b21c1
 github.com/containerd/continuity c6cef34830231743494fe2969284df7b82cc0ad0
 github.com/pkg/errors e881fd58d78e04cf6d0de1217f8707c8cc2249bc
 github.com/containerd/containerd 1a560540b9a1ab7dcdf657502b2f4db0ae067b30

--- a/vendor/github.com/tonistiigi/fsutil/copy/copy_linux.go
+++ b/vendor/github.com/tonistiigi/fsutil/copy/copy_linux.go
@@ -7,7 +7,6 @@ import (
 	"syscall"
 
 	"github.com/containerd/containerd/sys"
-	"github.com/containerd/continuity/sysx"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
@@ -74,24 +73,6 @@ func copyFileContent(dst, src *os.File) error {
 		first = false
 		written += int64(n)
 	}
-	return nil
-}
-
-func copyXAttrs(dst, src string) error {
-	xattrKeys, err := sysx.LListxattr(src)
-	if err != nil {
-		return errors.Wrapf(err, "failed to list xattrs on %s", src)
-	}
-	for _, xattr := range xattrKeys {
-		data, err := sysx.LGetxattr(src, xattr)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get xattr %q on %s", xattr, src)
-		}
-		if err := sysx.LSetxattr(dst, xattr, data, 0); err != nil {
-			return errors.Wrapf(err, "failed to set xattr %q on %s", xattr, dst)
-		}
-	}
-
 	return nil
 }
 

--- a/vendor/github.com/tonistiigi/fsutil/copy/copy_nowindows.go
+++ b/vendor/github.com/tonistiigi/fsutil/copy/copy_nowindows.go
@@ -1,0 +1,28 @@
+// +build !windows
+
+package fs
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/containerd/continuity/sysx"
+)
+
+// copyXAttrs requires xeh to be non-nil
+func copyXAttrs(dst, src string, xeh XAttrErrorHandler) error {
+	xattrKeys, err := sysx.LListxattr(src)
+	if err != nil {
+		return xeh(dst, src, "", errors.Wrapf(err, "failed to list xattrs on %s", src))
+	}
+	for _, xattr := range xattrKeys {
+		data, err := sysx.LGetxattr(src, xattr)
+		if err != nil {
+			return xeh(dst, src, xattr, errors.Wrapf(err, "failed to get xattr %q on %s", xattr, src))
+		}
+		if err := sysx.LSetxattr(dst, xattr, data, 0); err != nil {
+			return xeh(dst, src, xattr, errors.Wrapf(err, "failed to set xattr %q on %s", xattr, dst))
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/tonistiigi/fsutil/copy/copy_unix.go
+++ b/vendor/github.com/tonistiigi/fsutil/copy/copy_unix.go
@@ -8,7 +8,6 @@ import (
 	"syscall"
 
 	"github.com/containerd/containerd/sys"
-	"github.com/containerd/continuity/sysx"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
@@ -43,24 +42,6 @@ func copyFileContent(dst, src *os.File) error {
 	bufferPool.Put(buf)
 
 	return err
-}
-
-func copyXAttrs(dst, src string) error {
-	xattrKeys, err := sysx.LListxattr(src)
-	if err != nil {
-		return errors.Wrapf(err, "failed to list xattrs on %s", src)
-	}
-	for _, xattr := range xattrKeys {
-		data, err := sysx.LGetxattr(src, xattr)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get xattr %q on %s", xattr, src)
-		}
-		if err := sysx.LSetxattr(dst, xattr, data, 0); err != nil {
-			return errors.Wrapf(err, "failed to set xattr %q on %s", xattr, dst)
-		}
-	}
-
-	return nil
 }
 
 func copyDevice(dst string, fi os.FileInfo) error {


### PR DESCRIPTION
This commit allows ignoring errors during copying xattr like security.selinux,
which is not always supported.

Reported in several issues including
* openfaas/openfaas-cloud#312
* moby/buildkit#704
* genuinetools/img#45
* https://bugzilla.redhat.com/show_bug.cgi?id=1596918

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

---

requires https://github.com/tonistiigi/fsutil/pull/55
@tonistiigi 